### PR TITLE
Handbook capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Custom capabilities for the Handbook post type
+- Plugin activation & update hooks for managing capabilities
 
 ### Changed
+- Handbook pages can now be viewed (but not edited) by Authors
+- The default capability for viewing the handbook admin page is now `read_private_handbooks`
+- Show helpdesk info only for users who can edit handbook posts
 
 ### Deprecated
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Download and install [Git Updater](https://git-updater.com/). Git Updater will a
 
 ### Install Editor Handbook
 
-1. Download the ZIP file from the most recent release on the [Releases page](https://github.com/devcollaborative/editor-handbook/releases). 
+1. Download the ZIP file from the most recent release on the [Releases page](https://github.com/devcollaborative/editor-handbook/releases).
 1. Install the ZIP through the WordPress Dashboard, or extract it to `wp-content/plugins/editor-handbook`
 
 ## Usage
@@ -26,3 +26,27 @@ To view the default WP post list go to Dashboard > Handbook > Edit Handbook.
 ### Page Templates
 
 This plugin doesn't provide any templates for the Handbook pages, so they will follow the [WordPress template hierarchy](https://developer.wordpress.org/themes/basics/template-hierarchy/#custom-post-types). You may have to make style adjustments or create a specific template (`single-handbook.php`) for Handbook pages.
+
+## Handbook Capabilities
+
+- **Administrators** and **Editors** have full access to read, update, and delete Handbook posts.
+- **Authors** have access to view Handbook posts.
+- **Subscribers** and **Contributors** don't have any access to Handbook posts.
+
+### Customizing Capabilities
+You can customize access to Handbook posts with a plugin like User Role Editor.
+
+Available capabilities:
+- edit_handbook
+- read_handbook
+- delete_handbook
+- edit_handbooks
+- edit_others_handbooks
+- delete_handbooks
+- publish_handbooks
+- read_private_handbooks
+- delete_private_handbooks
+- delete_published_handbooks
+- delete_others_handbooks
+- edit_private_handbooks
+- edit_published_handbooks

--- a/editor-handbook.php
+++ b/editor-handbook.php
@@ -199,9 +199,11 @@ function handbook_admin_page() {
 			<?php endforeach; ?>
 		</ul>
 
-		<h3>Still need help?</h3>
-		<p>If you still need help, reach out by filing a helpdesk ticket.</p>
-		<p><a href="https://devcollaborative.com/helpdesk" target="_blank">https://devcollaborative.com/helpdesk</a></p>
+		<?php if ( current_user_can( 'edit_handbooks' ) ): ?>
+			<h3>Still need help?</h3>
+			<p>If you still need help, reach out by filing a helpdesk ticket.</p>
+			<p><a href="https://devcollaborative.com/helpdesk" target="_blank">https://devcollaborative.com/helpdesk</a></p>
+		<?php endif; ?>
 	</div>
 
 	<?php

--- a/editor-handbook.php
+++ b/editor-handbook.php
@@ -12,6 +12,66 @@
 
 defined( 'ABSPATH' ) or exit;
 
+define( 'EDITOR_HANDBOOK_VERSION', '1.1.0' );
+
+/**
+ * Run plugin update process on activation.
+ */
+function editor_handbook_activate() {
+	editor_handbook_update_check();
+}
+register_activation_hook( __FILE__, 'editor_handbook_activate' );
+
+/**
+ * Checks the current plugins version, and runs the update process if versions don't match.
+ */
+function editor_handbook_update_check() {
+	if ( EDITOR_HANDBOOK_VERSION !== get_option( 'editor_handbook_version' ) ) {
+
+		// Update with new plugin version.
+		update_option( 'editor_handbook_version', EDITOR_HANDBOOK_VERSION );
+
+		// Set capabilities again, in case there have been updates.
+		editor_handbook_set_caps();
+	}
+}
+add_action( 'plugins_loaded', 'editor_handbook_update_check' );
+
+/**
+ * Add handbook capabilities.
+ */
+function editor_handbook_set_caps() {
+	$administrator = get_role('administrator');
+	$editor        = get_role('editor');
+	$author        = get_role('author');
+
+	$all_caps = array(
+		'edit_handbook',
+		'read_handbook',
+		'delete_handbook',
+		'edit_handbooks',
+		'edit_others_handbooks',
+		'delete_handbooks',
+		'publish_handbooks',
+		'read_private_handbooks',
+		'delete_private_handbooks',
+		'delete_published_handbooks',
+		'delete_others_handbooks',
+		'edit_private_handbooks',
+		'edit_published_handbooks',
+	);
+
+	// Give admins and editors full access.
+	foreach ($all_caps as $cap) {
+		$administrator->add_cap( $cap );
+		$editor->add_cap( $cap );
+	}
+
+	// Give authors read-only access.
+	$author->add_cap( 'read_handbooks' );
+	$author->add_cap( 'read_private_handbooks' );
+}
+
 /**
  *  Register Custom Post Type for handbook
  */
@@ -60,7 +120,8 @@ function devcollab_handbook_post_type() {
 		'can_export'            => true,
 		'has_archive'           => true,
 		'public' 								=> true,
-		'capability_type'       => 'post',
+		'capability_type'       => array( 'handbook', 'handbooks' ),
+		'map_meta_cap' 					=> true,
 	);
 	register_post_type( 'handbook', $args );
 
@@ -105,7 +166,7 @@ function handbook_admin_menu() {
     'edit.php?post_type=handbook',
     $handbook->labels->menu_name,
     $handbook->labels->menu_name,
-    'edit_posts',
+    'read_private_handbooks',
     'handbook',
     'handbook_admin_page',
 		0


### PR DESCRIPTION
@cparkinson Could you do a code review and test this?

This branch has two main differences:
- By default, authors have access to view the handbook
- Adds custom capabilities for the handbook custom post type, so capabilities can be adjusted per site if needed