### PR TITLE
Set page.php as default for displaying handbook pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Use page.php for displaying handbook pages
+- Added `editor_handbook_template` filter for customizing the page template
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -23,11 +23,30 @@ To view all posts go to Dashboard > Handbook > Handbook. This is a simplified li
 
 To view the default WP post list go to Dashboard > Handbook > Edit Handbook.
 
-### Page Templates
+## Filters
 
-This plugin doesn't provide any templates for the Handbook pages, so they will follow the [WordPress template hierarchy](https://developer.wordpress.org/themes/basics/template-hierarchy/#custom-post-types). You may have to make style adjustments or create a specific template (`single-handbook.php`) for Handbook pages.
+### `editor_handbook_template`
 
-## Handbook Capabilities
+Filters the template to use for displaying single handbook pages. Gets passed to `locate_template()`.
+
+#### Parameters
+
+`$template_names` *string|array*
+
+Filename of template(s) to use for displaying handbook posts.
+
+Default: `page.php`
+
+#### Example
+
+```php
+function my_handbook_template( $template_names ) {
+    return 'my-custom-handbook-template.php';
+}
+add_filter( 'editor_handbook_template', 'my_handbook_template' );
+```
+
+## Capabilities
 
 - **Administrators** and **Editors** have full access to read, update, and delete Handbook posts.
 - **Authors** have access to view Handbook posts.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ To view the default WP post list go to Dashboard > Handbook > Edit Handbook.
 
 Filters the template to use for displaying single handbook pages. Gets passed to `locate_template()`.
 
+After setting a new template, you need to flush the rewrite rules by going to the Settings > Permalinks page in the admin dashboard.
+
 #### Parameters
 
 `$template_names` *string|array*

--- a/editor-handbook.php
+++ b/editor-handbook.php
@@ -220,3 +220,24 @@ function handbook_archive_redirect($archive_template){
   return $archive_template;
 }
 add_filter( 'archive_template', 'handbook_archive_redirect' ) ;
+
+/**
+ * Retrieves a template file for displaying handbook posts.
+ */
+function handbook_template_include( $template ) {
+	if ('handbook' === get_post_type()) {
+		/**
+		 * Customize template to use for displaying handbook posts.
+		 *
+		 * @param string|array $template_names Template filename(s) to search for, in order.
+		 */
+		$template_names = apply_filters( 'editor_handbook_template', 'page.php' );
+
+		if ( $template_names ) {
+			return locate_template( $template_names );
+		}
+	}
+
+	return $template;
+}
+add_filter( 'template_include', 'handbook_template_include' );

--- a/editor-handbook.php
+++ b/editor-handbook.php
@@ -33,6 +33,9 @@ function editor_handbook_update_check() {
 
 		// Set capabilities again, in case there have been updates.
 		editor_handbook_set_caps();
+
+		// Flush permalinks so the new page template is recognized.
+		flush_rewrite_rules();
 	}
 }
 add_action( 'plugins_loaded', 'editor_handbook_update_check' );


### PR DESCRIPTION
@cparkinson This is ready for review!

I could use some feedback on the version number for this. Should this be a major 2.0.0 release? It's changing the page template, so if page.php doesn't work on existing sites, that would be a breaking change and warrant a major version. What do you think?