### PR TITLE
Add readme.txt & update plugin headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 

--- a/editor-handbook.php
+++ b/editor-handbook.php
@@ -1,13 +1,15 @@
 <?php
 /**
- * Plugin Name: DevCollaborative Editor Handbook
+ * Plugin Name: Editor Handbook
  * Plugin URI: https://github.com/devcollaborative/editor-handbook
- * Description: Private content type for in-site documentation
+ * Description: Adds internal documentation for site editors.
  * Version: 1.2.0
+ * Requires at least: 4.7
+ * Requires PHP: 8
  * Author: DevCollaborative
  * Author URI: https://devcollaborative.com/
- * GitHub Plugin URI: devcollaborative/editor-handbook
- * Primary Branch: main
+ * License: GPLv2 or later
+ * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  */
 
 defined( 'ABSPATH' ) or exit;

--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,10 @@
 === Editor Handbook ===
 Contributors: devcollab, hbrokmeier, cparkinson
 Tags: documentation
-Tested up to: 6.3
+Requires at least: 6.0
+Tested up to: 6.4
 Stable tag: 1.2.0
+Requires PHP: 8.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -10,18 +12,18 @@ Create private, internal documentation for a site's editors.
 
 == Description ==
 
-The Editor Handbook plugin provides a Handbook section for creating private, in-site documentation for site editors.
+The Editor Handbook plugin provides a Handbook menu item in the admin area and adds a Handbook custom post type for creating private, in-site documentation for site editors.
 
 Handbook pages display using the default page template.
 
 == Frequently Asked Questions ==
 
-= Who has access to handbook pages? =
-- **Administrators** and **Editors** can view, update, and delete handbook pages.
+= Who has access to Handbook pages? =
+- **Administrators** and **Editors** can view, update, and delete Handbook pages.
 - **Authors** can view Handbook pages.
-- **Subscribers** and **Contributors** don't have access to handbook pages.
+- **Subscribers** and **Contributors** don't have access to Handbook pages.
 
-= How can I customize the template used to display pages? =
+= How can I customize the template used to display Handbook posts? =
 Handbook pages are displayed using the `page.php` template. Use the `editor_handbook_template` filter to customize which template is used.
 
 `
@@ -39,4 +41,4 @@ After setting a new template, flush the rewrite rules by going to **Settings > P
 * Added: Custom capabilities for the Handbook post type
 * Added: Plugin activation & update hooks for managing capabilities
 * Changed: Handbook pages can now be viewed (but not edited) by Authors
-* Changed: The default capability for viewing the handbook admin page is now `read_private_handbooks`
+* Changed: The default capability for viewing the Handbook admin page is now `read_private_handbooks`

--- a/readme.txt
+++ b/readme.txt
@@ -1,28 +1,43 @@
-# Editor Handbook
+=== Editor Handbook ===
+Contributors: devcollab, hbrokmeier, cparkinson
+Tags: documentation
+Requires at least: 4.7
+Tested up to: 6.3
+Stable tag: 1.2.0
+License: GPLv2 or later
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
 Create private, internal documentation for a site's editors.
 
-## Description
+== Description ==
 
 The Editor Handbook plugin provides a Handbook section for creating private, in-site documentation for site editors.
 
 Handbook pages display using the default page template.
 
-## Frequently Asked Questions
+== Frequently Asked Questions ==
 
-### Who has access to handbook pages?
+= Who has access to handbook pages? =
 - **Administrators** and **Editors** can view, update, and delete handbook pages.
 - **Authors** can view Handbook pages.
 - **Subscribers** and **Contributors** don't have access to handbook pages.
 
-### How can I customize the template used to display pages?
+= How can I customize the template used to display pages? =
 Handbook pages are displayed using the `page.php` template. Use the `editor_handbook_template` filter to customize which template is used.
 
-```php
+`
 function my_handbook_template( $template_names ) {
   return 'my-custom-handbook-template.php';
 }
 add_filter( 'editor_handbook_template', 'my_handbook_template' );
-```
+`
 
 After setting a new template, flush the rewrite rules by going to **Settings > Permalinks** in the admin dashboard.
+
+== Changelog ==
+
+= 1.2.0 - 2023-06-06 =
+* Added: Custom capabilities for the Handbook post type
+* Added: Plugin activation & update hooks for managing capabilities
+* Changed: Handbook pages can now be viewed (but not edited) by Authors
+* Changed: The default capability for viewing the handbook admin page is now `read_private_handbooks`

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,6 @@
 === Editor Handbook ===
 Contributors: devcollab, hbrokmeier, cparkinson
 Tags: documentation
-Requires at least: 4.7
 Tested up to: 6.3
 Stable tag: 1.2.0
 License: GPLv2 or later


### PR DESCRIPTION
@cparkinson There are two values needed in the plugin for compatible PHP & WP versions. Do you have any input on which versions number to include for them?

**Requires at least**: The lowest WordPress version that the plugin will work on.
**Requires PHP**: The minimum required PHP version.

And, if you have any suggestions on wording or anything else to add to the readme.txt, that would be helpful!